### PR TITLE
update readme - new jitpack path since v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ fun camera(translate: Float, rotate: Vec2): Mat4 {
 - Add the dependency
 
 	    dependencies {
-	        implementation 'com.github.kotlin-graphics.glm:glm:<version>'
+	        implementation 'com.github.kotlin-graphics:glm:<version>'
 	    }
 	    
 - The [kotlin-test](https://github.com/kotlintest/kotlintest) matchers can be used by adding the following dependency


### PR DESCRIPTION
Since v0.10 the gradle implementation for jitpack changed.
This PR updates the dependency example in the readme accordingly to prevent confusion during the initial setup process.