### PR TITLE
Add VecXVars interface

### DIFF
--- a/src/main/kotlin/glm_/vec1/Vec1Vars.kt
+++ b/src/main/kotlin/glm_/vec1/Vec1Vars.kt
@@ -1,0 +1,15 @@
+package glm_.vec1
+
+interface Vec1Vars<T : Number> {
+    var x: T
+
+    fun component1() = x
+
+
+    // -- Component accesses --
+
+    operator fun get(index: Int) = when (index) {
+        0 -> x
+        else -> throw IndexOutOfBoundsException()
+    }
+}

--- a/src/main/kotlin/glm_/vec1/Vec1t.kt
+++ b/src/main/kotlin/glm_/vec1/Vec1t.kt
@@ -16,20 +16,12 @@ import java.nio.*
  * Created bY GBarbieri on 05.10.2016.
  */
 
-abstract class Vec1t<T : Number>(_x: T): ToBuffer {
+abstract class Vec1t<T : Number>(_x: T): Vec1Vars<T>, ToBuffer {
 
 //    @JvmField TODO bug
-    var x = _x
-
-    fun component1() = x
-
+    override var x = _x
 
     // -- Component accesses --
-
-    operator fun get(index: Int) = when (index) {
-        0 -> x
-        else -> throw IndexOutOfBoundsException()
-    }
 
     open operator fun set(index: Int, value: T) = when (index) {
         0 -> x = value

--- a/src/main/kotlin/glm_/vec2/Vec2Vars.kt
+++ b/src/main/kotlin/glm_/vec2/Vec2Vars.kt
@@ -1,0 +1,17 @@
+package glm_.vec2
+
+import glm_.vec1.Vec1Vars
+
+interface Vec2Vars<T : Number> : Vec1Vars<T> {
+    var y: T
+
+    fun component2() = y
+
+
+    // -- Component accesses --
+
+    override operator fun get(index: Int) = when (index) {
+        1 -> y
+        else -> super.get(index)
+    }
+}

--- a/src/main/kotlin/glm_/vec2/Vec2t.kt
+++ b/src/main/kotlin/glm_/vec2/Vec2t.kt
@@ -13,21 +13,9 @@ import java.nio.*
  * Created bY GBarbieri on 05.10.2016.
  */
 
-abstract class Vec2t<T : Number>: ToBuffer {
-
-    abstract var x: T
-    abstract var y: T
-
-    operator fun component1() = x
-    operator fun component2() = y
+abstract class Vec2t<T : Number>: Vec2Vars<T>, ToBuffer {
 
     // -- Component accesses --
-
-    operator fun get(index: Int) = when (index) {
-        0 -> x
-        1 -> y
-        else -> throw IndexOutOfBoundsException()
-    }
 
     abstract operator fun set(index: Int, value: Number)
 

--- a/src/main/kotlin/glm_/vec3/Vec3Vars.kt
+++ b/src/main/kotlin/glm_/vec3/Vec3Vars.kt
@@ -1,0 +1,17 @@
+package glm_.vec3
+
+import glm_.vec2.Vec2Vars
+
+interface Vec3Vars<T : Number> : Vec2Vars<T> {
+    var z: T
+
+    fun component3() = z
+
+
+    // -- Component accesses --
+
+    override operator fun get(index: Int) = when (index) {
+        2 -> z
+        else -> super.get(index)
+    }
+}

--- a/src/main/kotlin/glm_/vec3/Vec3t.kt
+++ b/src/main/kotlin/glm_/vec3/Vec3t.kt
@@ -9,25 +9,9 @@ import glm_.vec4.Vec4bool
 import glm_.vec4.Vec4t
 import java.nio.*
 
-abstract class Vec3t<T : Number>: ToBuffer {
-
-    abstract var x: T
-    abstract var y: T
-    abstract var z: T
-
-    operator fun component1() = x
-    operator fun component2() = y
-    operator fun component3() = z
-
+abstract class Vec3t<T : Number>: Vec3Vars<T>, ToBuffer {
 
     // -- Component accesses --
-
-    operator fun get(index: Int) = when (index) {
-        0 -> x
-        1 -> y
-        2 -> z
-        else -> throw IndexOutOfBoundsException()
-    }
 
     abstract operator fun set(index: Int, value: Number)
 

--- a/src/main/kotlin/glm_/vec4/Vec4Vars.kt
+++ b/src/main/kotlin/glm_/vec4/Vec4Vars.kt
@@ -1,0 +1,17 @@
+package glm_.vec4
+
+import glm_.vec3.Vec3Vars
+
+interface Vec4Vars<T : Number> : Vec3Vars<T> {
+    var w: T
+
+    fun component4() = w
+
+
+    // -- Component accesses --
+
+    override operator fun get(index: Int) = when (index) {
+        3 -> w
+        else -> super.get(index)
+    }
+}

--- a/src/main/kotlin/glm_/vec4/Vec4t.kt
+++ b/src/main/kotlin/glm_/vec4/Vec4t.kt
@@ -10,25 +10,7 @@ import glm_.vec3.Vec3t
 import java.nio.*
 
 // TODO other
-abstract class Vec4t<T : Number> : ToBuffer {
-
-    abstract var x: T
-    abstract var y: T
-    abstract var z: T
-    abstract var w: T
-
-    operator fun component1() = x
-    operator fun component2() = y
-    operator fun component3() = z
-    operator fun component4() = w
-
-    operator fun get(index: Int) = when (index) {
-        0 -> x
-        1 -> y
-        2 -> z
-        3 -> w
-        else -> throw IndexOutOfBoundsException()
-    }
+abstract class Vec4t<T : Number> : Vec4Vars<T>, ToBuffer {
 
     abstract operator fun set(index: Int, value: Number)
 


### PR DESCRIPTION
These interfaces allow, for instance, using a Vec4 in place of a Vec3 if a function uses the Vec3Vars interface. Initially, I was going to turn VecXt into an interface, but it seemed to cause inconsistent behaviour in terms of the `put` functions (e.g. if you `put` with an array of length 2 on a Vec2t, but the value is, in reality, a Vec4, it would cause an exception). 

There are a few places in [imgui](https://github.com/kotlin-graphics/imgui) where these interfaces would reduce duplication