### PR TITLE
Vec2::times(Float)

### DIFF
--- a/src/main/kotlin/glm_/vec2/Vec2i.kt
+++ b/src/main/kotlin/glm_/vec2/Vec2i.kt
@@ -252,6 +252,7 @@ class Vec2i(@JvmField var ofs: Int, @JvmField var array: IntArray) : Vec2t<Int>,
 
 
     infix operator fun times(b: Int) = times(Vec2i(), this, b, b)
+    infix operator fun times(b: Float) = times(Vec2i(), this, b, b)
     infix operator fun times(b: Vec2i) = times(Vec2i(), this, b.x, b.y)
 
     @JvmOverloads
@@ -350,6 +351,7 @@ class Vec2i(@JvmField var ofs: Int, @JvmField var array: IntArray) : Vec2t<Int>,
 
     infix operator fun times(b: Number) = times(Vec2i(), this, b.i, b.i)
     infix operator fun times(b: Vec2t<out Number>) = times(Vec2i(), this, b._x.i, b._y.i)
+    infix operator fun times(b: Vec2) = times(Vec2i(), this, b.x, b.y)
 
     @JvmOverloads
     fun times(bX: Number, bY: Number, res: Vec2i = Vec2i()) = times(res, this, bX.i, bY.i)

--- a/src/main/kotlin/glm_/vec2/operators/opVec2i.kt
+++ b/src/main/kotlin/glm_/vec2/operators/opVec2i.kt
@@ -37,6 +37,12 @@ interface opVec2i {
         return res
     }
 
+    fun times(res: Vec2i, a: Vec2i, bX: Float, bY: Float): Vec2i {
+        res.x = (a.x * bX).toInt()
+        res.y = (a.y * bY).toInt()
+        return res
+    }
+
     fun div(res: Vec2i, a: Vec2i, bX: Int, bY: Int): Vec2i {
         res.x = a.x / bX
         res.y = a.y / bY


### PR DESCRIPTION
This is a common multiplication that is done. The problem is, if you multiply by 0.x then it is casted to an int (and before to a number object), so you multiply by 0 and then the result is 0. You normally don't expect that (and it is causing unneeded memory allocation)